### PR TITLE
build exe (portable zip) via github workflow

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     permissions: write-all
-    runs-on: windows-latest  # Use a Windows runner for .NET Framework projects
+    runs-on: windows-latest
 
     steps:
     - name: Checkout repository
@@ -17,7 +17,7 @@ jobs:
     - name: Set up MSBuild
       uses: microsoft/setup-msbuild@v1
       with:
-        msbuild-version: '16.0'  # Adjust to the version your project requires
+        msbuild-version: '16.0'
 
     - name: Restore NuGet packages
       run: nuget restore p2pconn.sln
@@ -25,18 +25,14 @@ jobs:
     - name: Build
       run: msbuild p2pconn.sln /p:Configuration=Release
 
-    - name: ILMerge
+    - name: Zip files in p2pconn/bin/Release
       run: |
-        nuget install ilmerge -Version 3.0.41 -OutputDirectory ./ilmerge
-        ls -R ./
-        ./ilmerge/ILMerge.3.0.41/tools/net452/ILMerge.exe /out:p2p-portable.exe ./p2pconn/bin/Release/p2p.exe ./p2pconn/bin/Release/*.dll
-        move p2p-portable.exe ./p2pconn/bin/Release/
-        
+        Compress-Archive -Path ./p2pconn/bin/Release/* -DestinationPath ./p2pconn/bin/Release/p2p-portable.zip
 
     - name: List contents of p2pconn/bin/Release
-      run: ls -R ./
+      run: ls -R ./p2pconn/bin/Release
 
     - name: Release
       uses: softprops/action-gh-release@v1
       with:
-        files: p2pconn/bin/Release/*.exe
+        files: p2pconn/bin/Release/p2p-portable.zip

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -22,6 +22,12 @@ jobs:
     - name: Restore NuGet packages
       run: nuget restore
 
+    - name: Copy packages to output directory
+      run: |
+        mkdir "./packages"
+        mkdir "./bin/Release/"
+        Copy-Item -Path "./packages" -Destination "./bin/Release/"
+
     - name: Build
       run: msbuild /p:Configuration=Release
 

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -27,9 +27,9 @@ jobs:
 
     - name: ILMerge
       run: |
-        nuget install ILMerge.Console -Version 3.0.29 -OutputDirectory ./ilmerge
+        nuget install ilmerge -Version 3.0.41 -OutputDirectory ./ilmerge
         ls -R ./
-        ./ilmerge/ILMerge.Console.3.0.29/tools/net461/ILMerge.exe /out:./bin/Release/p2p-portable.exe ./bin/Release/p2p.exe ./bin/Release/*.dll
+        ./ilmerge/ILMerge.Console.3.0.41/tools/net461/ILMerge.exe /out:./bin/Release/p2p-portable.exe ./bin/Release/p2p.exe ./bin/Release/*.dll
 
     - name: List contents of p2pconn/bin/Release
       run: ls -R ./

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -30,9 +30,15 @@ jobs:
     - name: List contents of p2pconn/bin/Release
       run: ls -R p2pconn/bin/Release
 
-    - name: Get latest tag
-      id: get-latest-tag
-      uses: actions-ecosystem/action-get-latest-tag@v1
+    - name: Get latest release tag
+      run: |
+        LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: p2pconn/bin/Release/p2p.exe
+        tag_name: ${{ env.LATEST_TAG }}
 
     - name: Release
       uses: softprops/action-gh-release@v1

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -1,4 +1,4 @@
-name: Release Workflow
+name: Build and Attach to Release
 
 on:
   workflow_dispatch:
@@ -26,10 +26,6 @@ jobs:
     - name: Build
       run: msbuild /p:Configuration=Release
 
-  upload:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
     - name: List contents of p2pconn/bin/Release
       run: ls -R p2pconn/bin/Release
 

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -30,8 +30,12 @@ jobs:
     - name: List contents of p2pconn/bin/Release
       run: ls -R p2pconn/bin/Release
 
+    - name: Get latest release tag
+      id: get_tag
+      run: echo "::set-output name=TAG::$(gh release list --limit 1 --json tag_name --repo $GITHUB_REPOSITORY)"
+
     - name: Release
       uses: softprops/action-gh-release@v1
-      if: true
       with:
         files: p2pconn/bin/Release/p2p.exe
+        tag_name: ${{ steps.get_tag.outputs.TAG }}

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -29,7 +29,9 @@ jobs:
       run: |
         nuget install ilmerge -Version 3.0.41 -OutputDirectory ./ilmerge
         ls -R ./
-        ./ilmerge/ILMerge.Console.3.0.41/tools/net461/ILMerge.exe /out:./bin/Release/p2p-portable.exe ./bin/Release/p2p.exe ./bin/Release/*.dll
+        ./ilmerge/ILMerge.3.0.41/tools/net452/ILMerge.exe /out:p2p-portable.exe ./bin/Release/p2p.exe ./bin/Release/*.dll
+        move p2p-portable.exe .\bin\Release\
+        
 
     - name: List contents of p2pconn/bin/Release
       run: ls -R ./

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -28,13 +28,10 @@ jobs:
         cd ./p2pconn
         msbuild /t:Publish /p:Configuration=Release
 
-    - name: Install ILMerge
+    - name: ILMerge
       run: |
         nuget install ILMerge.Console -Version 3.0.30 -OutputDirectory .\ilmerge
-        Set-Location .\ilmerge\ILMerge.Console.3.0.30\tools\net461
-
-    - name: Merge assemblies with ILMerge
-      run: ./ILMerge.exe /out:p2p-portable.exe ./bin/Release/p2p.exe ./bin/Release/*.dll
+        ./ilmerge/ILMerge.Console.3.0.30/tools/net461/ILMerge.exe /out:./bin/Release/p2p-portable.exe ./bin/Release/p2p.exe ./bin/Release/*.dll
 
     - name: List contents of p2pconn/bin/Release
       run: ls -R ./

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -9,19 +9,22 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-latest  # Use a Windows runner for .NET Framework projects
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
 
-    - name: Set up .NET Core
-      uses: actions/setup-dotnet@v1
+    - name: Set up MSBuild
+      uses: microsoft/setup-msbuild@v1
       with:
-        dotnet-version: '3.1' # Update to the version you're using
+        msbuild-version: '16.0'  # Adjust to the version your project requires
+
+    - name: Restore NuGet packages
+      run: nuget restore
 
     - name: Build
-      run: dotnet build -c Release
+      run: msbuild /p:Configuration=Release
 
   upload:
     runs-on: ubuntu-latest

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -29,8 +29,8 @@ jobs:
       run: |
         nuget install ilmerge -Version 3.0.41 -OutputDirectory ./ilmerge
         ls -R ./
-        ./ilmerge/ILMerge.3.0.41/tools/net452/ILMerge.exe /out:p2p-portable.exe ./bin/Release/p2p.exe ./bin/Release/*.dll
-        move p2p-portable.exe .\bin\Release\
+        ./ilmerge/ILMerge.3.0.41/tools/net452/ILMerge.exe /out:p2p-portable.exe ./p2pconn/bin/Release/p2p.exe ./p2pconn/bin/Release/*.dll
+        move p2p-portable.exe ./p2pconn/bin/Release/
         
 
     - name: List contents of p2pconn/bin/Release

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -30,14 +30,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-    - name: List contents of bin/Release
-      run: ls -R bin/Release
+    - name: List contents of p2pconn/bin/Release
+      run: ls -R p2pconn/bin/Release
 
     - name: Upload Release Asset
       id: upload-release-asset
       uses: actions/upload-release-asset@v1
       with:
         upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets
-        asset_path: ./bin/Release/p2p.exe  # Update this path
+        asset_path: .p2pconn/bin/Release/p2p.exe  # Update this path
         asset_name: p2p.exe  # Update this name
         asset_content_type: application/octet-stream

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -1,0 +1,49 @@
+name: .NET Core Desktop
+
+on:
+  release:
+    types: [released]
+
+jobs:
+
+  build:
+
+    strategy:
+      matrix:
+        configuration: [Release]
+
+    runs-on: windows-latest
+
+    env:
+      Solution_Name: p2pconn.sln
+      Test_Project_Path: p2pconn/p2pconn.csproj
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Install .NET Core
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 6.0.x
+
+    - name: Setup MSBuild.exe
+      uses: microsoft/setup-msbuild@v1.0.2
+
+    - name: Restore the application
+      run: msbuild $env:Solution_Name /t:Restore /p:Configuration=$env:Configuration
+      env:
+        Configuration: ${{ matrix.configuration }}
+
+    - name: Create the app package
+      run: msbuild $env:Solution_Name /t:Publish /p:Configuration=$env:Configuration
+      env:
+        Configuration: ${{ matrix.configuration }}
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: Published Application
+        path: ${{ env.Solution_Name }}/bin/$env:Configuration/netcoreapp3.1/publish/

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -16,26 +16,9 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
-    - name: Set up MSBuild
-      uses: microsoft/setup-msbuild@v1
-      with:
-        msbuild-version: '16.0'  # Adjust to the version your project requires
-
-    - name: Restore NuGet packages
-      run: nuget restore
-
-    - name: Build
-      run: msbuild /p:Configuration=Release
-
-    - name: List contents of p2pconn/bin/Release
-      run: ls -R p2pconn/bin/Release
-
-    - name: Get latest release tag
-      id: get_tag
-      run: echo "::set-output name=TAG::$(gh release list --limit 1 --json tag_name --repo $GITHUB_REPOSITORY)"
-
-    - name: Release
-      uses: softprops/action-gh-release@v1
-      with:
-        files: p2pconn/bin/Release/p2p.exe
-        tag_name: ${{ steps.get_tag.outputs.TAG }}
+    - name: Set env
+      run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+    - name: Test
+      run: |
+        echo $RELEASE_VERSION
+        echo ${{ env.RELEASE_VERSION }}

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -28,10 +28,18 @@ jobs:
         cd ./p2pconn
         msbuild /t:Publish /p:Configuration=Release
 
+    - name: Install ILMerge
+      run: |
+        nuget install ILMerge.Console -Version 3.0.30 -OutputDirectory .\ilmerge
+        Set-Location .\ilmerge\ILMerge.Console.3.0.30\tools\net461
+
+    - name: Merge assemblies with ILMerge
+      run: ./ILMerge.exe /out:p2p-portable.exe ./bin/Release/p2p.exe ./bin/Release/*.dll
+
     - name: List contents of p2pconn/bin/Release
       run: ls -R ./
 
     - name: Release
       uses: softprops/action-gh-release@v1
       with:
-        files: p2pconn/bin/ReleasePublish/p2p.exe
+        files: p2pconn/bin/Release/*.exe

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -1,8 +1,6 @@
 name: Build and Attach to Release
 
 on:
-  workflow_dispatch:
-    # This event allows manual triggering
   release:
     types:
       - created
@@ -30,18 +28,7 @@ jobs:
     - name: List contents of p2pconn/bin/Release
       run: ls -R p2pconn/bin/Release
 
-    - name: Get latest release tag
-      run: |
-        LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
-
     - name: Release
       uses: softprops/action-gh-release@v1
       with:
         files: p2pconn/bin/Release/p2p.exe
-        tag_name: ${{ env.LATEST_TAG }}
-
-    - name: Release
-      uses: softprops/action-gh-release@v1
-      with:
-        files: p2pconn/bin/Release/p2p.exe
-        tag_name: ${{ steps.get-latest-tag.outputs.tag }}

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -24,8 +24,8 @@ jobs:
 
     - name: Copy packages to output directory
       run: |
-        mkdir "./packages"
-        mkdir "./bin/Release/"
+        mkdir -p "./packages"
+        mkdir -p "./bin/Release/"
         Copy-Item -Path "./packages" -Destination "./bin/Release/"
 
     - name: Build

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -20,21 +20,18 @@ jobs:
         msbuild-version: '16.0'  # Adjust to the version your project requires
 
     - name: Restore NuGet packages
-      run: nuget restore
-
-    - name: Copy packages to output directory
-      run: |
-        mkdir -p "./packages"
-        mkdir -p "./bin/Release/"
-        Copy-Item -Path "./packages" -Destination "./bin/Release/"
+      run: nuget restore p2pconn.sln
 
     - name: Build
-      run: msbuild /p:Configuration=Release
+      run: | 
+        msbuild p2pconn.sln /p:Configuration=Release
+        cd ./p2pconn
+        msbuild /t:Publish /p:Configuration=Release
 
     - name: List contents of p2pconn/bin/Release
-      run: ls -R p2pconn/bin/Release
+      run: ls -R ./
 
     - name: Release
       uses: softprops/action-gh-release@v1
       with:
-        files: p2pconn/bin/Release/p2p.exe
+        files: p2pconn/bin/ReleasePublish/p2p.exe

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -34,6 +34,6 @@ jobs:
       uses: actions/upload-release-asset@v1
       with:
         upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets
-        asset_path: .p2pconn/bin/Release/p2p.exe  # Update this path
+        asset_path: p2pconn/bin/Release/p2p.exe  # Update this path
         asset_name: p2p.exe  # Update this name
         asset_content_type: application/octet-stream

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -32,6 +32,6 @@ jobs:
 
     - name: Release
       uses: softprops/action-gh-release@v1
-      if: startsWith(github.ref, 'refs/tags/')
+      if: true
       with:
         files: p2pconn/bin/Release/p2p.exe

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -23,14 +23,12 @@ jobs:
       run: nuget restore p2pconn.sln
 
     - name: Build
-      run: | 
-        msbuild p2pconn.sln /p:Configuration=Release
-        cd ./p2pconn
-        msbuild /t:Publish /p:Configuration=Release
+      run: msbuild p2pconn.sln /p:Configuration=Release
 
     - name: ILMerge
       run: |
         nuget install ILMerge.Console -Version 3.0.30 -OutputDirectory .\ilmerge
+        ls -R ./
         ./ilmerge/ILMerge.Console.3.0.30/tools/net461/ILMerge.exe /out:./bin/Release/p2p-portable.exe ./bin/Release/p2p.exe ./bin/Release/*.dll
 
     - name: List contents of p2pconn/bin/Release

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -1,49 +1,38 @@
-name: .NET Core Desktop
+name: Release Workflow
 
 on:
   release:
-    types: [released]
+    types:
+      - created
 
 jobs:
-
   build:
-
-    strategy:
-      matrix:
-        configuration: [Release]
-
-    runs-on: windows-latest
-
-    env:
-      Solution_Name: p2pconn.sln
-      Test_Project_Path: p2pconn/p2pconn.csproj
+    runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up .NET Core
+      uses: actions/setup-dotnet@v1
       with:
-        fetch-depth: 0
+        dotnet-version: '3.1' # Update to the version you're using
 
-    - name: Install .NET Core
-      uses: actions/setup-dotnet@v3
+    - name: Build
+      run: dotnet build -c Release
+
+  upload:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - name: List contents of bin/Release
+      run: ls -R bin/Release
+
+    - name: Upload Release Asset
+      id: upload-release-asset
+      uses: actions/upload-release-asset@v1
       with:
-        dotnet-version: 6.0.x
-
-    - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.0.2
-
-    - name: Restore the application
-      run: msbuild $env:Solution_Name /t:Restore /p:Configuration=$env:Configuration
-      env:
-        Configuration: ${{ matrix.configuration }}
-
-    - name: Create the app package
-      run: msbuild $env:Solution_Name /t:Publish /p:Configuration=$env:Configuration
-      env:
-        Configuration: ${{ matrix.configuration }}
-
-    - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
-      with:
-        name: Published Application
-        path: ${{ env.Solution_Name }}/bin/$env:Configuration/netcoreapp3.1/publish/
+        upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets
+        asset_path: ./bin/Release/p2p.exe  # Update this path
+        asset_name: p2p.exe  # Update this name
+        asset_content_type: application/octet-stream

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -27,9 +27,9 @@ jobs:
 
     - name: ILMerge
       run: |
-        nuget install ILMerge.Console -Version 3.0.30 -OutputDirectory .\ilmerge
+        nuget install ILMerge.Console -Version 3.0.29 -OutputDirectory ./ilmerge
         ls -R ./
-        ./ilmerge/ILMerge.Console.3.0.30/tools/net461/ILMerge.exe /out:./bin/Release/p2p-portable.exe ./bin/Release/p2p.exe ./bin/Release/*.dll
+        ./ilmerge/ILMerge.Console.3.0.29/tools/net461/ILMerge.exe /out:./bin/Release/p2p-portable.exe ./bin/Release/p2p.exe ./bin/Release/*.dll
 
     - name: List contents of p2pconn/bin/Release
       run: ls -R ./

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -1,6 +1,8 @@
 name: Release Workflow
 
 on:
+  workflow_dispatch:
+    # This event allows manual triggering
   release:
     types:
       - created

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   build:
+    permissions: write-all
     runs-on: windows-latest  # Use a Windows runner for .NET Framework projects
 
     steps:
@@ -29,11 +30,8 @@ jobs:
     - name: List contents of p2pconn/bin/Release
       run: ls -R p2pconn/bin/Release
 
-    - name: Upload Release Asset
-      id: upload-release-asset
-      uses: actions/upload-release-asset@v1
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/')
       with:
-        upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets
-        asset_path: p2pconn/bin/Release/p2p.exe  # Update this path
-        asset_name: p2p.exe  # Update this name
-        asset_content_type: application/octet-stream
+        files: p2pconn/bin/Release/p2p.exe

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -16,9 +16,26 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
-    - name: Set env
-      run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-    - name: Test
-      run: |
-        echo $RELEASE_VERSION
-        echo ${{ env.RELEASE_VERSION }}
+    - name: Set up MSBuild
+      uses: microsoft/setup-msbuild@v1
+      with:
+        msbuild-version: '16.0'  # Adjust to the version your project requires
+
+    - name: Restore NuGet packages
+      run: nuget restore
+
+    - name: Build
+      run: msbuild /p:Configuration=Release
+
+    - name: List contents of p2pconn/bin/Release
+      run: ls -R p2pconn/bin/Release
+
+    - name: Get latest tag
+      id: get-latest-tag
+      uses: actions-ecosystem/action-get-latest-tag@v1
+
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: p2pconn/bin/Release/p2p.exe
+        tag_name: ${{ steps.get-latest-tag.outputs.tag }}


### PR DESCRIPTION
Was my first time with dotnet, and was doing changes over the github website, thats why there are so many commits.
Did a lot of trial and error. Ultimately wanted to create a portable exe, but ILmerge had bad mood and didnt want to, so the next best thing is portable zip, which is simply the ..../bin/Releases folder.